### PR TITLE
Remove using `-o` CLI argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 LFX Actions are a series of tools that can be either ran directly at the CLI or leveraged via GitHub Actions, which automate pulling data from LFX for using with other tools and services. The current list of tools provided is as below:
 
-- `updateprojects` pulls hosted project data from a project's landscape into a CSV file.
-- `updatetacmembers` pulls the current list of TAC members from LFX PCC into a CSV file.
-- `updatetacagendaitems` is for TACs that use a GitHub Project for managing their TAC agenda; the tool exports the data into a CSV file.
-- `updateclomonitor` pulls hosted project data from a project's landscape into a file that can imported into [CLOMonitor](https://github.com/cncf/clomonitor)
-- `updatecharters` pulls the Technical Charters for the subprojects of a project, saving them in a specified directory with naming format of `SLUG_charter`
-- `updatedecks` exports Google Slides and Powerpoint decks from Google Drive, saving them in PDF and PPTX format in a specified directory.
+- `updateprojects`: Pulls hosted project data from a project's landscape and streams in CSV format to `stdout`.
+- `updatetacmembers`: Pulls the current list of TAC members from LFX PCC and streams CSV format to `stdout`.
+- `updatetacagendaitems`: A tool for TACs that use a GitHub Project for managing their TAC agenda. Streams TAC agenda items in CSV format to `stdout`..
+- `updateclomonitor`: Pulls hosted project data from a project's landscape in YAML format to `stdout` that can imported into [CLOMonitor](https://github.com/cncf/clomonitor).
+- `updatecharters`: Downloads the Technical Charters for the subprojects of a project identified by `--slug`, saving them in the current working directory with naming format of `SLUG_charter`.
+- `updatedecks`: Exports Google Slides and Powerpoint decks from Google Drive, saving them in PDF and PPTX format in the current working directory.
 
 You can run any of these commands with the `-h` flag to see the command line arguments required.
 

--- a/action.yml
+++ b/action.yml
@@ -63,14 +63,14 @@ runs:
     run: |
       # 1. Try github.action_ref (works for tags/branches)
       TARGET_VERSION="${{ github.action_ref }}"
-      
+
       # 2. If blank, check if the action was invoked via a specific commit SHA
       # GitHub stores the repository data in a hidden internal format we can parse
       if [ -z "$TARGET_VERSION" ]; then
         # Extracts the SHA from the tail end of the internal action path if present
         TARGET_VERSION=$(echo "${{ github.action_path }}" | grep -oE '[0-9a-f]{40}$')
       fi
-      
+
       # 3. Final safety fallback to main
       if [ -z "$TARGET_VERSION" ]; then
         TARGET_VERSION="main"
@@ -82,34 +82,36 @@ runs:
     shell: bash
     if: inputs.updateprojects == 'true' && inputs.landscape_url != ''
     run: |
-      updateprojects -o _data/projects.csv --landscape_url ${{ inputs.landscape_url }}
+      updateprojects --landscape_url ${{ inputs.landscape_url }} -l INFO > _data/projects.csv
   - name: Run updatetacmembers
     shell: bash
     if: inputs.updatetacmembers == 'true' && inputs.lfx_tac_committee_url != ''
     run: |
-      updatetacmembers -o _data/tacmembers.csv --lfx_tac_committee_url ${{ inputs.lfx_tac_committee_url }}
+      updatetacmembers --lfx_tac_committee_url ${{ inputs.lfx_tac_committee_url }} -l INFO > _data/tacmembers.csv
   - name: Run updatetacagendaitems
     shell: bash
     if: inputs.updatetacagendaitems == 'true' && inputs.tac_agenda_gh_project_url != ''
     env:
       GH_TOKEN: ${{ env.token }}
     run: |
-      updatetacagendaitems -o _data/meeting-agenda-items.csv --tac_agenda_gh_project_url ${{ inputs.tac_agenda_gh_project_url }}
+      updatetacagendaitems --tac_agenda_gh_project_url ${{ inputs.tac_agenda_gh_project_url }} -l INFO > _data/meeting-agenda-items.csv
   - name: Run updateclomonitor
     shell: bash
     if: inputs.updateclomonitor == 'true' && inputs.landscape_url != ''
     run: |
-      updateclomonitor -o _data/meeting-agenda-items.csv --landscape_url ${{ inputs.landscape_url }}
+      updateclomonitor --landscape_url ${{ inputs.landscape_url }} -l INFO > _data/meeting-agenda-items.csv
   - name: Run updatecharters
     shell: bash
     if: inputs.updatecharters == 'true' && inputs.slug != ''
     run: |
-      updatecharters -o project_charters --slug ${{ inputs.slug }} -l INFO
+      mkdir -p project_charters
+      (cd project_charters && updatecharters --slug ${{ inputs.slug }} -l INFO)
   - name: Run updatedecks
     shell: bash
     if: inputs.updatedecks == 'true' && inputs.overview_decks != ''
     run: |
-      updatedecks -o overview_deck --overview_decks '${{ inputs.overview_decks }}'
+      mkdir -p overview_deck
+      (cd overview_deck && updatedecks --overview_decks '${{ inputs.overview_decks }}' -l INFO)
   - name: Get current date
     id: date
     uses: Kaven-Universe/github-action-current-date-time@7c1d8465d1bfd7d35466d2ee82a8e460780561ae # v1.5.0

--- a/lfx_tac_actions/__init__.py
+++ b/lfx_tac_actions/__init__.py
@@ -5,4 +5,11 @@
 #
 # encoding=utf8
 
+import logging
+import sys
 
+def setup_logging(log_level):
+    numeric_level = getattr(logging, log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f'Invalid log level: {log_level}')
+    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',stream=sys.stderr)

--- a/lfx_tac_actions/updatecharters.py
+++ b/lfx_tac_actions/updatecharters.py
@@ -13,8 +13,6 @@ from pathlib import Path
 import logging
 import re
 
-from pathvalidate.argparse import validate_filename_arg, validate_filepath_arg
-
 from . import setup_logging
 
 def main(args=None):

--- a/lfx_tac_actions/updatecharters.py
+++ b/lfx_tac_actions/updatecharters.py
@@ -10,8 +10,8 @@ import os
 from urllib.parse import urlparse, quote
 import argparse
 from pathlib import Path
-import re
 import logging
+import re
 
 from pathvalidate.argparse import validate_filename_arg, validate_filepath_arg
 

--- a/lfx_tac_actions/updatecharters.py
+++ b/lfx_tac_actions/updatecharters.py
@@ -18,7 +18,7 @@ from pathvalidate.argparse import validate_filename_arg, validate_filepath_arg
 from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Downloads the Technical Charters for the subprojects of a project identified by --slug, saving them in a specified directory with naming format of `SLUG_charter`.")
+    parser = argparse.ArgumentParser(description="Downloads the Technical Charters for the subprojects of a project identified by `--slug`, saving them in the current working directory with naming format of `SLUG_charter`.")
     parser.add_argument("-s", "--slug", help="Umbrella Foundation slug", required=True)
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     args = parser.parse_args(args)

--- a/lfx_tac_actions/updatecharters.py
+++ b/lfx_tac_actions/updatecharters.py
@@ -10,22 +10,20 @@ import os
 from urllib.parse import urlparse, quote
 import argparse
 from pathlib import Path
-import logging
 import re
+import logging
 
 from pathvalidate.argparse import validate_filename_arg, validate_filepath_arg
+
+from . import setup_logging
 
 def main(args=None):
     parser = argparse.ArgumentParser(description="Downloads the Technical Charters for the subprojects of a project identified by --slug, saving them in a specified directory with naming format of `SLUG_charter`.")
     parser.add_argument("-s", "--slug", help="Umbrella Foundation slug", required=True)
-    parser.add_argument("-o", "--output", help="location to save output to", default='.', type=validate_filepath_arg)
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     args = parser.parse_args(args)
 
-    numeric_level = getattr(logging, args.log_level.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {args.log_level}')
-    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    setup_logging(args.log_level)
 
     endpoint_url = 'https://api-gw.platform.linuxfoundation.org/project-service/v1/public/projects?$filter=parentSlug%20eq%20{}%20and%20status%20eq%20Active&pageSize=2000&orderBy=name'
 
@@ -54,7 +52,7 @@ def main(args=None):
                 with requests.get(record['CharterURL'],stream=False) as response:
                     response.raise_for_status()
                     _, extension = os.path.splitext(urlparse(record['CharterURL']).path)
-                    with open(Path(args.output,f"{record['Slug']}_charter").with_suffix(extension), 'wb') as f:
+                    with open((Path.cwd() / f"{record['Slug']}_charter").with_suffix(extension), 'wb') as f:
                         logging.info("Writing file {}".format(f.name))
                         f.write(response.content)
             except Exception as e:

--- a/lfx_tac_actions/updateclomonitor.py
+++ b/lfx_tac_actions/updateclomonitor.py
@@ -89,7 +89,7 @@ def is_safe_url(url):
         return False
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape in YAML format to stdout that can imported into CLOMonitor.")
+    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape in YAML format to `stdout` that can imported into CLOMonitor.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--landscape_url", help="URL to the project's landscape",required=True)
     args = parser.parse_args(args)

--- a/lfx_tac_actions/updateclomonitor.py
+++ b/lfx_tac_actions/updateclomonitor.py
@@ -11,10 +11,10 @@ import requests
 import urllib.parse
 import json
 import os
+import logging
 import ipaddress
 import socket
 from pathlib import Path
-import logging
 import sys
 
 from pathvalidate.argparse import validate_filename_arg, validate_filepath_arg

--- a/lfx_tac_actions/updateclomonitor.py
+++ b/lfx_tac_actions/updateclomonitor.py
@@ -11,12 +11,15 @@ import requests
 import urllib.parse
 import json
 import os
-import logging
 import ipaddress
 import socket
 from pathlib import Path
+import logging
+import sys
 
 from pathvalidate.argparse import validate_filename_arg, validate_filepath_arg
+
+from . import setup_logging
 
 def load_from_artwork_repo(artwork_url):
     urlparts = urllib.parse.urlparse(artwork_url)
@@ -85,33 +88,21 @@ def is_safe_url(url):
         logging.exception(f"URL validation failed with error: {e}")
         return False
 
-def setup_logging(log_level):
-    numeric_level = getattr(logging, log_level.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {log_level}')
-    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape into a file that can imported into CLOMonitor.")
-    parser.add_argument("-o", "--output", help="filename to save output to",default='clomonitor.yaml',type=validate_filepath_arg)
+    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape in YAML format to stdout that can imported into CLOMonitor.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--landscape_url", help="URL to the project's landscape",required=True)
     args = parser.parse_args(args)
 
     setup_logging(args.log_level)
 
-    if Path(args.output).suffix.lower() != '.yaml':
-        logging.critical(f"Output filename {args.output} is invalid (must have extension '.yaml')")
-        return
-
-    if not is_safe_url(args.landscape_url):
-        logging.critical("Execution aborted due to unsafe landscape_url.")
-        return
-
     project_entries = []
 
     try:
         landscape_hosted_projects = urllib.parse.urljoin(args.landscape_url,'api/projects/all.json')
+        if not is_safe_url(landscape_hosted_projects):
+            logging.critical("Execution aborted due to unsafe landscape_url.")
+            return
         hosted_projects_response = requests.get(landscape_hosted_projects)
         hosted_projects_response.raise_for_status()
         project_data = hosted_projects_response.json()
@@ -151,9 +142,11 @@ def main(args=None):
             logging.info(f"Adding {project.get('name')}")
             project_entries.append({k: v for k, v in project_entry.items() if v})
 
-    with open(args.output, 'w') as clomonitor_file_object:
-        logging.info(f"Saving file {clomonitor_file_object.name}")
-        yaml.dump(project_entries, clomonitor_file_object, sort_keys=False, indent=2)
+    if not project_entries:
+        logging.warning("No valid data retrieved.")
+        return
+
+    yaml.dump(project_entries, sys.stdout, sort_keys=False, indent=2)
 
 if __name__ == '__main__':
     main()

--- a/lfx_tac_actions/updatedecks.py
+++ b/lfx_tac_actions/updatedecks.py
@@ -18,7 +18,7 @@ from pathvalidate import is_valid_filename
 from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Exports Google Slides and Powerpoint decks from Google Drive, saving them in PDF and PPTX format in a specified directory.")
+    parser = argparse.ArgumentParser(description="Exports Google Slides and Powerpoint decks from Google Drive, saving them in PDF and PPTX format in the current working directory.")
     parser.add_argument("--overview_decks", required=True, help="JSON array of Google Presentations to export ( format is '[{'url': GOOGLE-DRIVE-URL,'filename': EXPORT_FILENAME},...]' )")
     parser.add_argument("-o", "--output", help="location to save output to",default='.',type=validate_filepath_arg)
     parser.add_argument("--export_formats", help="Comma delimited lists of export formats", default="pdf,pptx")

--- a/lfx_tac_actions/updatedecks.py
+++ b/lfx_tac_actions/updatedecks.py
@@ -15,11 +15,7 @@ import logging
 from pathvalidate.argparse import validate_filepath_arg
 from pathvalidate import is_valid_filename
 
-def setup_logging(log_level):
-    numeric_level = getattr(logging, log_level.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {log_level}')
-    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+from . import setup_logging
 
 def main(args=None):
     parser = argparse.ArgumentParser(description="Exports Google Slides and Powerpoint decks from Google Drive, saving them in PDF and PPTX format in a specified directory.")
@@ -44,7 +40,7 @@ def main(args=None):
                         if not is_valid_filename(document['filename']):
                             logging.critical(f"Security Error: {document['filename']} contains invalid characters")
                             return
-                        with open(Path(args.output,document['filename']).with_suffix(f".{export_format.lstrip('.')}"), 'wb') as f:
+                        with open((Path.cwd() / document['filename']).with_suffix(f".{export_format.lstrip('.')}"), 'wb') as f:
                             logging.info("Writing file {}".format(f.name))
                             f.write(response.content)
                 except Exception as e:

--- a/lfx_tac_actions/updateprojects.py
+++ b/lfx_tac_actions/updateprojects.py
@@ -18,7 +18,7 @@ import logging
 from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape and streams in CSV format to stdout.")
+    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape and streams in CSV format to `stdout`.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--landscape_url", help="URL to the project's landscape",required=True)
     args = parser.parse_args(args)

--- a/lfx_tac_actions/updateprojects.py
+++ b/lfx_tac_actions/updateprojects.py
@@ -11,25 +11,19 @@ import json
 import os
 import argparse
 import urllib.parse
-import logging
 from pathlib import Path
+import sys
+import logging
 
-from pathvalidate.argparse import validate_filepath_arg
+from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape into a CSV file.")
-    parser.add_argument("-o", "--output", help="filename to save output to",default='projects.csv',type=validate_filepath_arg)
+    parser = argparse.ArgumentParser(description="Pulls hosted project data from a project's landscape and streams in CSV format to stdout.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--landscape_url", help="URL to the project's landscape",required=True)
     args = parser.parse_args(args)
 
-    numeric_level = getattr(logging, args.log_level.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {args.log_level}')
-    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-    if Path(args.output).suffix.lower() != '.csv':
-        logging.critical(f"Output filename {args.output} is invalid (must have extension '.csv')")
+    setup_logging(args.log_level)
 
     landscape_hosted_projects = urllib.parse.urljoin(args.landscape_url,'api/projects/all.json')
 
@@ -76,11 +70,13 @@ def main(args=None):
             'Contributed By': project.get('annotations',{}).get('contributed_by'),
             })
 
-    with open(args.output, 'w') as csv_file_object:
-        logging.info(f"Saving file {csv_file_object.name}")
-        writer = csv.DictWriter(csv_file_object, fieldnames = csv_rows[0].keys())
-        writer.writeheader()
-        writer.writerows(csv_rows)
+    if not csv_rows:
+        logging.warning("No valid data retrieved.")
+        return
+
+    writer = csv.DictWriter(sys.stdout, fieldnames = csv_rows[0].keys())
+    writer.writeheader()
+    writer.writerows(csv_rows)
 
 if __name__ == '__main__':
     main()

--- a/lfx_tac_actions/updateprojects.py
+++ b/lfx_tac_actions/updateprojects.py
@@ -11,9 +11,9 @@ import json
 import os
 import argparse
 import urllib.parse
+import logging
 from pathlib import Path
 import sys
-import logging
 
 from . import setup_logging
 

--- a/lfx_tac_actions/updatetacagendaitems.py
+++ b/lfx_tac_actions/updatetacagendaitems.py
@@ -12,25 +12,18 @@ import os
 import subprocess
 from urllib.parse import urlparse
 import argparse
-import logging
 from pathlib import Path
+import logging
 
-from pathvalidate.argparse import validate_filepath_arg
+from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="A tool for TACs that use a GitHub Project for managing their TAC agenda; the tool exports the data into a CSV file.")
-    parser.add_argument("-o", "--output", help="filename to save output to",default='tacagenda.csv',type=validate_filepath_arg)
+    parser = argparse.ArgumentParser(description="A tool for TACs that use a GitHub Project for managing their TAC agenda. Streams TAC agenda items in CSV format to stdout")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--tac_agenda_gh_project_url", help="URL to the TAC agenda GitHub Project",required=True)
     args = parser.parse_args(args)
 
-    numeric_level = getattr(logging, args.log_level.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {args.log_level}')
-    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-    if Path(args.output).suffix.lower() != '.csv':
-        logging.critical(f"Output filename {args.output} is invalid (must have extension '.csv')")
+    setup_logging(args.log_level)
 
     urlparts = urlparse(args.tac_agenda_gh_project_url).path.split('/')
     if not urlparts or len(urlparts) < 5 or urlparts[1] != 'orgs' or urlparts[3] != 'projects':
@@ -72,11 +65,13 @@ def main(args=None):
             meeting_item['meeting_label'] = None
         csv_rows.append(meeting_item)
 
-    with open(args.output, 'w') as csv_file_object:
-        logging.info(f"Saving file {csv_file_object.name}")
-        writer = csv.DictWriter(csv_file_object, fieldnames = csv_rows[0].keys())
-        writer.writeheader()
-        writer.writerows(csv_rows)
+    if not csv_rows:
+        logging.warning("No valid data retrieved.")
+        return
+
+    writer = csv.DictWriter(sys.stdout, fieldnames = csv_rows[0].keys())
+    writer.writeheader()
+    writer.writerows(csv_rows)
 
 if __name__ == '__main__':
     main()

--- a/lfx_tac_actions/updatetacagendaitems.py
+++ b/lfx_tac_actions/updatetacagendaitems.py
@@ -18,7 +18,7 @@ import logging
 from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="A tool for TACs that use a GitHub Project for managing their TAC agenda. Streams TAC agenda items in CSV format to stdout")
+    parser = argparse.ArgumentParser(description="A tool for TACs that use a GitHub Project for managing their TAC agenda. Streams TAC agenda items in CSV format to `stdout`.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--tac_agenda_gh_project_url", help="URL to the TAC agenda GitHub Project",required=True)
     args = parser.parse_args(args)

--- a/lfx_tac_actions/updatetacagendaitems.py
+++ b/lfx_tac_actions/updatetacagendaitems.py
@@ -12,8 +12,8 @@ import os
 import subprocess
 from urllib.parse import urlparse
 import argparse
-from pathlib import Path
 import logging
+from pathlib import Path
 
 from . import setup_logging
 

--- a/lfx_tac_actions/updatetacmembers.py
+++ b/lfx_tac_actions/updatetacmembers.py
@@ -10,11 +10,10 @@ import csv
 import requests
 import json
 import os
-import sys
-import logging
 from urllib.parse import urlparse
-from pathlib import Path
 import logging
+from pathlib import Path
+import sys
 
 from pathvalidate.argparse import validate_filepath_arg
 

--- a/lfx_tac_actions/updatetacmembers.py
+++ b/lfx_tac_actions/updatetacmembers.py
@@ -21,7 +21,7 @@ from pathvalidate.argparse import validate_filepath_arg
 from . import setup_logging
 
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Pulls the current list of TAC members from LFX PCC and streams CSV format to stdout.")
+    parser = argparse.ArgumentParser(description="Pulls the current list of TAC members from LFX PCC and streams CSV format to `stdout`.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--lfx_tac_committee_url", help="URL to the TAC Committee in LFX PCC", required=True)
     args = parser.parse_args(args)

--- a/lfx_tac_actions/updatetacmembers.py
+++ b/lfx_tac_actions/updatetacmembers.py
@@ -10,26 +10,23 @@ import csv
 import requests
 import json
 import os
-from urllib.parse import urlparse
+import sys
 import logging
+from urllib.parse import urlparse
 from pathlib import Path
+import logging
 
 from pathvalidate.argparse import validate_filepath_arg
 
+from . import setup_logging
+
 def main(args=None):
-    parser = argparse.ArgumentParser(description="Pulls the current list of TAC members from LFX PCC into a CSV file.")
-    parser.add_argument("-o", "--output", help="filename to save output to",default='tacmembers.csv',type=validate_filepath_arg)
+    parser = argparse.ArgumentParser(description="Pulls the current list of TAC members from LFX PCC and streams CSV format to stdout.")
     parser.add_argument('--log-level','-l',default='WARNING',help='Provide logging level. Example: --log-level DEBUG, default: WARNING')
     parser.add_argument("--lfx_tac_committee_url", help="URL to the TAC Committee in LFX PCC", required=True)
     args = parser.parse_args(args)
 
-    numeric_level = getattr(logging, args.log_level.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {args.log_level}')
-    logging.basicConfig(level=numeric_level,format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-    if Path(args.output).suffix.lower() != '.csv':
-        logging.critical(f"Output filename {args.output} is invalid (must have extension '.csv')")
+    setup_logging(args.log_level)
 
     committee_url = 'https://api-gw.platform.linuxfoundation.org/project-service/v2/public/projects/{project_id}/committees/{committee_id}/members'
 
@@ -59,11 +56,13 @@ def main(args=None):
             'HeadshotURL': committee_member.get('LogoURL')
             })
 
-    with open(args.output, 'w') as csv_file_object:
-        logging.info(f"Saving file {csv_file_object.name}")
-        writer = csv.DictWriter(csv_file_object, fieldnames = csv_rows[0].keys())
-        writer.writeheader()
-        writer.writerows(csv_rows)
+    if not csv_rows:
+        logging.warning("No valid data retrieved.")
+        return
+
+    writer = csv.DictWriter(sys.stdout, fieldnames = csv_rows[0].keys())
+    writer.writeheader()
+    writer.writerows(csv_rows)
 
 if __name__ == '__main__':
     main()

--- a/test/test_updatecharters.py
+++ b/test/test_updatecharters.py
@@ -11,11 +11,13 @@ import os
 import responses
 import argparse
 from pathlib import Path
+import io
+from unittest.mock import patch
 
 from lfx_tac_actions.updatecharters import main
 
 class TestUpdateCharters(unittest.TestCase):
-    
+
     def testMainNoSlug(self):
         with self.assertRaises(SystemExit) as cm:
             main(["-o",""])
@@ -34,7 +36,7 @@ class TestUpdateCharters(unittest.TestCase):
             status=404,
             body="Not here!"
             )
-        
+
         with self.assertLogs(level="CRITICAL") as cm:
             main(["--slug","lfenergy"])
         self.assertIn('Error getting charters at https://api-gw.platform.linuxfoundation.org/project-service/v1/public/projects?$filter=parentSlug%20eq%20lfenergy%20and%20status%20eq%20Active&pageSize=2000&orderBy=name', str(cm.output[0]))
@@ -99,9 +101,13 @@ class TestUpdateCharters(unittest.TestCase):
 
 
         with tempfile.TemporaryDirectory() as tempdir:
-            with self.assertLogs(level="ERROR") as cm:
-                main(["-o",tempdir,"--slug","lfenergy"])
-            
+            with (
+                patch.object(os, "chdir", os.chdir),
+                self.assertLogs(level="ERROR") as cm,
+            ):
+                os.chdir(tempdir)
+                main(["--slug","lfenergy"])
+
             self.assertTrue(os.path.isfile(Path(tempdir,"arras_charter.pdf")))
             self.assertFalse(os.path.isfile(Path(tempdir,"citrineos_charter.pdf")))
             self.assertFalse(os.path.isfile(Path(tempdir,"badproject_charter.pdf")))

--- a/test/test_updateclomonitor.py
+++ b/test/test_updateclomonitor.py
@@ -10,17 +10,30 @@ import tempfile
 import os
 import responses
 import argparse
+import io
+import sys
+from unittest.mock import patch
 
 from lfx_tac_actions.updateclomonitor import main
 
 class TestUpdateCLOMonitor(unittest.TestCase):
 
     def testMainNoLandscapeUrl(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.yaml')
-            main(["-o",tmpfilepath,"--landscape_url",""])
+        with self.assertLogs(level="ERROR") as cm:
+            main(["--landscape_url",""])
 
-        self.assertLogs("Error getting landscape_url api/projects/all.json - error message 'Invalid URL 'api/projects/all.json': No scheme supplied. Perhaps you meant https://api/projects/all.json?", level='CRITICAL')
+        self.assertTrue(
+            any(
+                "Invalid URL scheme: . Only HTTP and HTTPS are allowed" in output
+                for output in cm.output
+            )
+        )
+        self.assertTrue(
+            any(
+                "Execution aborted due to unsafe landscape_url." in output
+                for output in cm.output
+            )
+        )
 
     def testBadLogLevel(self):
         with self.assertRaises(ValueError) as cm:
@@ -97,13 +110,15 @@ class TestUpdateCLOMonitor(unittest.TestCase):
                 }
                 ]
             )
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.yaml')
-            main(["-o",tmpfilepath,"--landscape_url","https://landscape.aswf.io"])
+        captured_stdout = io.StringIO()
 
-            with open(tmpfilepath, 'r') as tmpfile:
-                self.maxDiff = None
-                self.assertEqual(tmpfile.read(),'''[]\n''')
+        with (self.assertLogs(level="WARNING") as cm, patch("sys.stdout", new=captured_stdout)):
+            main(["--landscape_url","https://landscape.aswf.io"])
+
+        self.assertIn("No valid data retrieved", str(cm.output[0]))
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue().replace("\r\n", "\n"),'')
 
     @responses.activate
     def testMainInvalidArtworkUrl(self):
@@ -182,15 +197,15 @@ class TestUpdateCLOMonitor(unittest.TestCase):
                 }
                 ]
             )
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.yaml')
-            with self.assertLogs(level="ERROR") as cm:
-                main(["-o",tmpfilepath,"--landscape_url","https://landscape.aswf.io"])
-            self.assertIn("Error getting artwork repo file https://artwork.aswf.io/assets/data.json - error message '404 Client Error: Not Found for url: https://artwork.aswf.io/assets/data.json", str(cm.output[0]))
+        captured_stdout = io.StringIO()
 
-            with open(tmpfilepath, 'r') as tmpfile:
-                self.maxDiff = None
-                self.assertEqual(tmpfile.read(),'''- name: opencolorio
+        with (self.assertLogs(level="ERROR") as cm, patch("sys.stdout", new=captured_stdout)):
+            main(["--landscape_url","https://landscape.aswf.io"])
+
+        self.assertIn("Error getting artwork repo file https://artwork.aswf.io/assets/data.json - error message '404 Client Error: Not Found for url: https://artwork.aswf.io/assets/data.json", str(cm.output[0]))
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue().replace("\r\n", "\n"),'''- name: opencolorio
   display_name: OpenColorIO
   description: The OpenColorIO project is committed to providing an industry standard
     solution for highly precise, performant, and consistent color management across
@@ -279,13 +294,13 @@ class TestUpdateCLOMonitor(unittest.TestCase):
                 }
                 ]
             )
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.yaml')
-            main(["-o",tmpfilepath,"--landscape_url","https://landscape.aswf.io"])
+        captured_stdout = io.StringIO()
 
-            with open(tmpfilepath, 'r') as tmpfile:
-                self.maxDiff = None
-                self.assertEqual(tmpfile.read(),'''- name: opencolorio
+        with patch("sys.stdout", new=captured_stdout):
+            main(["--landscape_url","https://landscape.aswf.io"])
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue().replace("\r\n", "\n"),'''- name: opencolorio
   display_name: OpenColorIO
   description: The OpenColorIO project is committed to providing an industry standard
     solution for highly precise, performant, and consistent color management across
@@ -390,13 +405,13 @@ class TestUpdateCLOMonitor(unittest.TestCase):
                 }
                 ]
             )
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.yaml')
-            main(["-o",tmpfilepath,"--landscape_url","https://landscape.aswf.io"])
+        captured_stdout = io.StringIO()
 
-            with open(tmpfilepath, 'r') as tmpfile:
-                self.maxDiff = None
-                self.assertEqual(tmpfile.read(),'''- name: opencolorio
+        with patch("sys.stdout", new=captured_stdout):
+            main(["--landscape_url","https://landscape.aswf.io"])
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue().replace("\r\n", "\n"),'''- name: opencolorio
   display_name: OpenColorIO
   description: The OpenColorIO project is committed to providing an industry standard
     solution for highly precise, performant, and consistent color management across

--- a/test/test_updatedecks.py
+++ b/test/test_updatedecks.py
@@ -12,16 +12,21 @@ import responses
 import argparse
 from pathlib import Path
 import re
+import io
+from unittest.mock import patch
 
 from lfx_tac_actions.updatedecks import main
 
 class TestUpdateDecks(unittest.TestCase):
-    
+
     def testMainNoArgs(self):
-        with self.assertRaises(SystemExit) as cm:
-            main(["-o",""])
+        with (
+            patch("sys.stderr", new=io.StringIO()),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            main([])
         self.assertEqual(cm.exception.code, 2)
-    
+
     def testBadLogLevel(self):
         with self.assertRaises(ValueError) as cm:
             main(["-l","BAD","--overview_decks","foo"])
@@ -45,11 +50,15 @@ class TestUpdateDecks(unittest.TestCase):
             status=404,
             body="Not here!"
             )
-        
+
         with tempfile.TemporaryDirectory() as tempdir:
-            with self.assertLogs(level="ERROR") as cm:
-                main(["-o",tempdir,"--overview_decks",overview_decks])
-            
+            with (
+                patch.object(os, "chdir", os.chdir),
+                self.assertLogs(level="ERROR") as cm,
+            ):
+                os.chdir(tempdir)
+                main(["--overview_decks",overview_decks])
+
             self.assertIn("Error getting overview deck https://docs.google.com/presentation/d/1p0FoFJ7-IdDejisJPUYdq_uApn3XW3wJ/edit?usp=sharing&ouid=108330571292091021915&rtpof=true&sd=true - 404 Client Error: Not Found for url: https://docs.google.com/feeds/download/presentations/Export?id=1p0FoFJ7-IdDejisJPUYdq_uApn3XW3wJ&exportFormat=pdf", str(cm.output[0]))
             self.assertTrue(os.path.isfile(Path(tempdir,"ASWF High Level Overview.pdf")))
             self.assertTrue(os.path.isfile(Path(tempdir,"ASWF Governing Board Overview.pdf")))

--- a/test/test_updateprojects.py
+++ b/test/test_updateprojects.py
@@ -10,16 +10,24 @@ import tempfile
 import os
 import responses
 import argparse
+import io
+from unittest.mock import patch
 
 from lfx_tac_actions.updateprojects import main
 
 class TestUpdateProjects(unittest.TestCase):
-    
+
     def testMainNoLandscapeUrl(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-            main(["-o",tmpfilepath,"--landscape_url",""])
-            self.assertFalse(os.path.exists(tmpfilepath), f"File '{tmpfilepath}' exists.")
+        with self.assertLogs(level="CRITICAL") as log_context:
+            main(["--landscape_url", ""])
+
+        self.assertTrue(
+            any(
+                "Error getting landscape_url" in output
+                for output in log_context.output
+            ),
+            f"Expected log message not found in {log_context.output}",
+        )
 
     def testBadLogLevel(self):
         with self.assertRaises(ValueError) as cm:
@@ -88,13 +96,13 @@ class TestUpdateProjects(unittest.TestCase):
                   }
                 ]
             )
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-            main(["-o",tmpfilepath,"--landscape_url","https://landscape.aswf.io"])
+        captured_stdout = io.StringIO()
 
-            with open(tmpfilepath, 'r') as tmpfile:
-                self.maxDiff = None
-                self.assertEqual(tmpfile.read(),'Name,Level,Logo URL,Slug,Categories,Website,Chair,TAC Representative,Documentation,Calendar,Artwork,iCal,LFX Insights URL,Accepted Date,Last Review Date,Next Review Date,Slack URL,Chat Channel,Mailing List,Github Org,Best Practices Badge ID,Primary Github Repo,Contributed By\nASWF Language Interop Project,working-group,https://aswf.landscape2.io/logos/803e21319d55195829c27a3bc448d43e8f14dbcf544e4d44418299df3a3cca61.svg,aswf-language-interop-project,"ASWF Projects / All,Math and Simulation / Math Foundations",https://github.com/vfx-rs,Scott Wilson,,,https://zoom-lfx.platform.linuxfoundation.org/meetings/aswf-language-interop-project,https://artwork.aswf.io/projects/aswf-language-interop-project/,https://webcal.prod.itx.linuxfoundation.org/lfx/lfv8NMKI8tcp96N5tb,https://insights.lfx.linuxfoundation.org/foundation/aswf/overview?project=aswf-language-interop-project,2023-10-20,2024-03-20,2025-03-19,https://slack.aswf.io,#rust,https://lists.aswf.io/g/wg-rust,https://github.com/vfx-rs,,https://github.com/vfx-rs/organization,\n')
+        with patch("sys.stdout", new=captured_stdout):
+            main(["--landscape_url","https://landscape.aswf.io"])
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue().replace("\r\n", "\n"),'Name,Level,Logo URL,Slug,Categories,Website,Chair,TAC Representative,Documentation,Calendar,Artwork,iCal,LFX Insights URL,Accepted Date,Last Review Date,Next Review Date,Slack URL,Chat Channel,Mailing List,Github Org,Best Practices Badge ID,Primary Github Repo,Contributed By\nASWF Language Interop Project,working-group,https://aswf.landscape2.io/logos/803e21319d55195829c27a3bc448d43e8f14dbcf544e4d44418299df3a3cca61.svg,aswf-language-interop-project,"ASWF Projects / All,Math and Simulation / Math Foundations",https://github.com/vfx-rs,Scott Wilson,,,https://zoom-lfx.platform.linuxfoundation.org/meetings/aswf-language-interop-project,https://artwork.aswf.io/projects/aswf-language-interop-project/,https://webcal.prod.itx.linuxfoundation.org/lfx/lfv8NMKI8tcp96N5tb,https://insights.lfx.linuxfoundation.org/foundation/aswf/overview?project=aswf-language-interop-project,2023-10-20,2024-03-20,2025-03-19,https://slack.aswf.io,#rust,https://lists.aswf.io/g/wg-rust,https://github.com/vfx-rs,,https://github.com/vfx-rs/organization,\n')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_updatetacagendaitems.py
+++ b/test/test_updatetacagendaitems.py
@@ -5,76 +5,140 @@
 #
 # encoding=utf8
 
-import unittest
-import tempfile
+import io
 import os
-import responses
-import argparse
+import sys
+import unittest
+from unittest.mock import Mock, patch
 
 from lfx_tac_actions.updatetacagendaitems import main
 
+
 class TestUpdateTACAgendaItems(unittest.TestCase):
-    
+
     def testMainNoTACAgendaUrl(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-            main(["-o",tmpfilepath,"--tac_agenda_gh_project_url",""])
-            self.assertFalse(os.path.exists(tmpfilepath), f"File '{tmpfilepath}' exists.")
+        captured_stdout = io.StringIO()
+        with (
+            self.assertLogs(level="CRITICAL") as cm,
+            patch("sys.stdout", new=captured_stdout),
+        ):
+            main(["--tac_agenda_gh_project_url", ""])
+
+        self.assertEqual(captured_stdout.getvalue(), "")
+        self.assertTrue(
+            any(
+                "Invalid value for tac_agenda_gh_project_url" in log_msg
+                for log_msg in cm.output
+            )
+        )
 
     def testBadLogLevel(self):
         with self.assertRaises(ValueError) as cm:
-            main(["-l","BAD","--tac_agenda_gh_project_url","foo"])
-        self.assertIn('Invalid log level: BAD', str(cm.exception))
+            main(["-l", "BAD", "--tac_agenda_gh_project_url", "foo"])
+        self.assertIn("Invalid log level: BAD", str(cm.exception))
 
     def testMainBrokenTACAgendaUrls(self):
         brokenurls = [
             "https://google.com/d/d",
             "https://github.com/orgs/openmainframeproject/settings",
-            ]
+        ]
         for brokenurl in brokenurls:
-            with tempfile.TemporaryDirectory() as tempdir:
-                tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-                main(["-o",tmpfilepath,"--tac_agenda_gh_project_url",brokenurl])
-                self.assertFalse(os.path.exists(tmpfilepath), f"File '{tmpfilepath}' exists.")
-    
-    @unittest.mock.patch('subprocess.run')
+            captured_stdout = io.StringIO()
+            with (
+                self.assertLogs(level="CRITICAL") as cm,
+                patch("sys.stdout", new=captured_stdout),
+            ):
+                main(["--tac_agenda_gh_project_url", brokenurl])
+
+            self.assertEqual(
+                captured_stdout.getvalue(),
+                "",
+                f"Expected no stdout output for broken URL '{brokenurl}'",
+            )
+            self.assertTrue(
+                any(
+                    "Invalid value for tac_agenda_gh_project_url" in log_msg
+                    for log_msg in cm.output
+                )
+            )
+
+    @patch("subprocess.run")
     def testMainInvalidJSONResponse(self, mock_run):
-        mock_result = unittest.mock.Mock()
-        mock_result.stdout = 'error 12121212'
-        mock_result.stderr = 'foo'
+        mock_result = Mock()
+        mock_result.stdout = "error 12121212"
+        mock_result.stderr = "foo"
         mock_run.return_value = mock_result
 
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-            main(["-o",tmpfilepath,"--tac_agenda_gh_project_url","https://github.com/orgs/openmainframeproject/projects/21"])
-            self.assertFalse(os.path.exists(tmpfilepath), f"File '{tmpfilepath}' exists.")
-    
-    @unittest.mock.patch.dict(os.environ, {"TAC_AGENDA_GH_PROJECT_URL": "https://github.com/orgs/openmainframeproject/projects/21"}, clear=True)
-    @unittest.mock.patch('subprocess.run')
+        captured_stdout = io.StringIO()
+        with (
+            self.assertLogs(level="ERROR") as cm,
+            patch("sys.stdout", new=captured_stdout),
+        ):
+            main(
+                [
+                    "--tac_agenda_gh_project_url",
+                    "https://github.com/orgs/openmainframeproject/projects/21",
+                ]
+            )
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue(), "")
+        self.assertTrue(
+            any(
+                "Invalid response from gh client" in log_msg
+                for log_msg in cm.output
+            )
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "TAC_AGENDA_GH_PROJECT_URL": "https://github.com/orgs/openmainframeproject/projects/21"
+        },
+        clear=True,
+    )
+    @patch("subprocess.run")
     def testMain(self, mock_run):
         labelList = {
-            '"2-annual-review"': '2-annual-review',
-            '"1-new-project-wg"': '1-new-project-wg',
-            '"2-annual-review-tac"': '2-annual-review',
-            '"2-annual-review-sig"': '2-annual-review-sig',
-            '"3-tac-meeting-long"': '3-tac-meeting-long',
-            '"4-tac-meeting-short"': '4-tac-meeting-short',
-            '"5-annual-review-sig"': '',
-            }
+            '"2-annual-review"': "2-annual-review",
+            '"1-new-project-wg"': "1-new-project-wg",
+            '"2-annual-review-tac"': "2-annual-review",
+            '"2-annual-review-sig"': "2-annual-review-sig",
+            '"3-tac-meeting-long"': "3-tac-meeting-long",
+            '"4-tac-meeting-short"': "4-tac-meeting-short",
+            '"5-annual-review-sig"': "",
+        }
         for label, output in labelList.items():
-            mock_result = unittest.mock.Mock()
-            mock_result.stdout = '{"items":[{"assignees":["carolalynn"],"content":{"body":"","number":473,"repository":"AcademySoftwareFoundation/tac","title":"D&I Working Group","type":"Issue","url":"https://github.com/AcademySoftwareFoundation/tac/issues/473"},"id":"PVTI_lADOAm6tAs4AS_w4zgJSO7E","labels":['+label+'],"landscape URL":"https://landscape.aswf.io/card-mode?project=working-group&selected=d-i-working-group","pCC Project ID":"a092M00001KWjDZQA1","pCC TSC Committee ID":"ac9cbe7f-0dc8-4be0-b404-cb7b9b0bb22f","repository":"https://github.com/AcademySoftwareFoundation/tac","scheduled Date":"2024-12-11","status":"Next Meeting Agenda Items","title":"D&I Working Group"}],"totalCount":32}'
+            mock_result = Mock()
+            mock_result.stdout = (
+                '{"items":[{"assignees":["carolalynn"],"content":{"body":"","number":473,'
+                '"repository":"AcademySoftwareFoundation/tac","title":"D&I Working Group","type":"Issue",'
+                '"url":"https://github.com/AcademySoftwareFoundation/tac/issues/473"},'
+                '"id":"PVTI_lADOAm6tAs4AS_w4zgJSO7E","labels":['
+                + label
+                + '],"landscape URL":"https://landscape.aswf.io/card-mode?project=working-group&selected=d-i-working-group",'
+                '"pCC Project ID":"a092M00001KWjDZQA1","pCC TSC Committee ID":"ac9cbe7f-0dc8-4be0-b404-cb7b9b0bb22f",'
+                '"repository":"https://github.com/AcademySoftwareFoundation/tac","scheduled Date":"2024-12-11",'
+                '"status":"Next Meeting Agenda Items","title":"D&I Working Group"}],"totalCount":32}'
+            )
             mock_run.return_value = mock_result
 
-            with tempfile.TemporaryDirectory() as tempdir:
-                tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-                main(["-o",tmpfilepath,"--tac_agenda_gh_project_url","https://github.com/orgs/openmainframeproject/projects/21"])
+            captured_stdout = io.StringIO()
+            with patch("sys.stdout", new=captured_stdout):
+                main(
+                    [
+                        "--tac_agenda_gh_project_url",
+                        "https://github.com/orgs/openmainframeproject/projects/21",
+                    ]
+                )
 
-                with open(tmpfilepath, 'r') as tmpfile:
-                    self.maxDiff = None
-                    self.assertEqual(tmpfile.read(),f'''title,url,number,scheduled_date,status,last_review_date,meeting_label
-D&I Working Group,https://github.com/AcademySoftwareFoundation/tac/issues/473,473,2024-12-11,Next Meeting Agenda Items,,{output}
-''')
+            self.maxDiff = None
+            expected_csv = (
+                "title,url,number,scheduled_date,status,last_review_date,meeting_label\r\n"
+                f"D&I Working Group,https://github.com/AcademySoftwareFoundation/tac/issues/473,473,2024-12-11,Next Meeting Agenda Items,,{output}\r\n"
+            )
+            self.assertEqual(captured_stdout.getvalue(), expected_csv)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_updatetacmembers.py
+++ b/test/test_updatetacmembers.py
@@ -10,16 +10,25 @@ import tempfile
 import os
 import responses
 import argparse
+import io
+import sys
+from unittest.mock import patch
 
 from lfx_tac_actions.updatetacmembers import main
 
 class TestUpdateTACMembers(unittest.TestCase):
-    
+
     def testMainNoLFXTACCommitteeURL(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-            main(["-o",tmpfilepath,"--lfx_tac_committee_url",""])
-            self.assertFalse(os.path.exists(tmpfilepath), f"File '{tmpfilepath}' exists.")
+        with self.assertLogs(level="CRITICAL") as log_context:
+            main(["--lfx_tac_committee_url", ""])
+
+        self.assertTrue(
+            any(
+                "Invalid value for lfx_tac_committee_url" in output
+                for output in log_context.output
+            ),
+            f"Expected log message not found in {log_context.output}",
+        )
 
     def testBadLogLevel(self):
         with self.assertRaises(ValueError) as cm:
@@ -34,9 +43,15 @@ class TestUpdateTACMembers(unittest.TestCase):
             ]
         for brokenurl in brokenurls:
             with tempfile.TemporaryDirectory() as tempdir:
-                tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-                main(["-o",tmpfilepath,"--lfx_tac_committee_url",brokenurl])
-                self.assertFalse(os.path.exists(tmpfilepath), f"File '{tmpfilepath}' exists.")
+                with self.assertLogs(level="CRITICAL") as log_context:
+                    main(["--lfx_tac_committee_url",brokenurl])
+                self.assertTrue(
+                    any(
+                        "Invalid value for lfx_tac_committee_url" in output
+                        for output in log_context.output
+                    ),
+                    f"Expected log message not found in {log_context.output}",
+                )
 
     @responses.activate
     def testMainInvalidResponse(self):
@@ -46,15 +61,14 @@ class TestUpdateTACMembers(unittest.TestCase):
             status=404,
             body="Not here!"
             )
-        
+
         with tempfile.TemporaryDirectory() as tempdir:
             tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
             with self.assertLogs(level="CRITICAL") as cm:
-                main(["-o",tmpfilepath,"--lfx_tac_committee_url","https://projectadmin.lfx.linuxfoundation.org/project/a0941000002wBymAAE/collaboration/committees/163b26f7-a49b-40a3-89bb-e0592296c003"])
+                main(["--lfx_tac_committee_url","https://projectadmin.lfx.linuxfoundation.org/project/a0941000002wBymAAE/collaboration/committees/163b26f7-a49b-40a3-89bb-e0592296c003"])
 
-            self.assertFalse(os.path.isfile(tmpfilepath))
             self.assertIn("Error getting https://api-gw.platform.linuxfoundation.org/project-service/v2/public/projects/a0941000002wBymAAE/committees/163b26f7-a49b-40a3-89bb-e0592296c003/members - 404 Client Error: Not Found for url: https://api-gw.platform.linuxfoundation.org/project-service/v2/public/projects/a0941000002wBymAAE/committees/163b26f7-a49b-40a3-89bb-e0592296c003/members", str(cm.output[0]))
-            
+
     @responses.activate
     def testMain(self):
         responses.add(
@@ -91,13 +105,13 @@ class TestUpdateTACMembers(unittest.TestCase):
                 ]
               }
             )
-        with tempfile.TemporaryDirectory() as tempdir:
-            tmpfilepath = os.path.join(tempdir, 'someFileInTmpDir.csv')
-            main(["-o",tmpfilepath,"--lfx_tac_committee_url","https://projectadmin.lfx.linuxfoundation.org/project/a0941000002wBymAAE/collaboration/committees/163b26f7-a49b-40a3-89bb-e0592296c003"])
+        captured_stdout = io.StringIO()
 
-            with open(tmpfilepath, 'r') as tmpfile:
-                self.maxDiff = None
-                self.assertEqual(tmpfile.read(),'''Full Name,Account Name: Account Name,Appointed By,Voting Status,Special Role,Title,HeadshotURL\nAndrea Orth,State Farm Mutual Automobile Insurance Company,Vote of TSC Committee,Voting Rep,None,Scrum Master,https://avatars0.githubusercontent.com/u/61636929?v=4\n''')
+        with patch("sys.stdout", new=captured_stdout):
+            main(["--lfx_tac_committee_url","https://projectadmin.lfx.linuxfoundation.org/project/a0941000002wBymAAE/collaboration/committees/163b26f7-a49b-40a3-89bb-e0592296c003"])
+
+        self.maxDiff = None
+        self.assertEqual(captured_stdout.getvalue().replace("\r\n", "\n"),'''Full Name,Account Name: Account Name,Appointed By,Voting Status,Special Role,Title,HeadshotURL\nAndrea Orth,State Farm Mutual Automobile Insurance Company,Vote of TSC Committee,Voting Rep,None,Scrum Master,https://avatars0.githubusercontent.com/u/61636929?v=4\n''')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instead:

- For `updateclomonitor` write YAML directly to `stdout`.
- For `updateprojects`, `updatetacagendaitems`, and `updatetacmembers` output CSV to `stdout`.
- Write files to `cwd` for `updatedecks` and `updatecharters`.